### PR TITLE
Return 500 error when contact email fails

### DIFF
--- a/api/contact.ts
+++ b/api/contact.ts
@@ -83,8 +83,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const fromEmail = process.env.CONTACT_FROM_EMAIL || "no-reply@geotecniayservicios.es";
 
   if (!resendKey) {
-    // Still succeed but warn client; record is saved already
-    return res.status(200).json({ ok: true, warning: "Falta RESEND_API_KEY, no se envió email" });
+    // Record already saved, but cannot send notification emails
+    return res.status(500).json({ error: "Falta RESEND_API_KEY, no se envió email" });
   }
 
   const resend = new Resend(resendKey);
@@ -113,7 +113,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     });
   } catch (err) {
     console.error("Error enviando correos de contacto", err);
-    return res.status(200).json({ ok: true, warning: "No se pudieron enviar los correos" });
+    return res.status(500).json({ error: "No se pudieron enviar los correos" });
   }
 
   return res.status(200).json({ ok: true });

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -147,7 +147,9 @@ const Index = () => {
         body: JSON.stringify({ nombre, email, empresa: empresa || null, mensaje, recaptchaToken })
       });
       const data = await res.json().catch(() => ({}));
-      if (!res.ok) throw new Error(data?.error || "No se pudo enviar tu solicitud");
+      if (!res.ok || !data?.ok) {
+        throw new Error(data?.error || "No se pudo enviar tu solicitud");
+      }
 
       toast({
         title: "Gracias por tu interés",


### PR DESCRIPTION
## Summary
- Return HTTP 500 with error details when Resend env vars are missing or email sending fails
- Client-side form now throws and displays an error if server response is not ok

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npx ts-node -e "import handler from './api/contact'; const req: any = { method: 'POST', body: { nombre: 'A', email: 'a@b.com', mensaje: 'hi' } }; const res: any = { status(code:number){this.statusCode=code;return this;}, json(data:any){console.log('status', this.statusCode, data);} }; handler(req, res);"` *(fails: Supabase no configurado)*

------
https://chatgpt.com/codex/tasks/task_b_68b32006ff0c832e9affccec5cc6b794