### PR TITLE
feat: enforce strict contact form validation

### DIFF
--- a/src/lib/contact-schema.ts
+++ b/src/lib/contact-schema.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+export const EMAIL_REGEX = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/;
+
+export const contactSchema = z.object({
+  nombre: z
+    .string()
+    .trim()
+    .min(2, { message: "El nombre debe tener al menos 2 caracteres" })
+    .max(100, { message: "El nombre es demasiado largo" })
+    .regex(/^[A-Za-zÁÉÍÓÚáéíóúÑñÜü'\s-]+$/, { message: "El nombre contiene caracteres inválidos" }),
+  email: z
+    .string()
+    .trim()
+    .toLowerCase()
+    .email({ message: "Email inválido" })
+    .max(254, { message: "Email demasiado largo" })
+    .regex(EMAIL_REGEX, { message: "Email inválido" }),
+  empresa: z
+    .string()
+    .trim()
+    .min(2, { message: "La empresa debe tener al menos 2 caracteres" })
+    .max(100, { message: "La empresa es demasiado larga" })
+    .optional(),
+  mensaje: z
+    .string()
+    .trim()
+    .min(10, { message: "El mensaje debe tener al menos 10 caracteres" })
+    .max(1000, { message: "El mensaje es demasiado largo" }),
+});
+
+export type ContactForm = z.infer<typeof contactSchema>;


### PR DESCRIPTION
## Summary
- add shared Zod schema for contact form fields
- validate contact data on client before sending
- apply same validation on API handler and sanitize database payload
- enforce strict email regex on both client and server

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b6ac720018832e93f34f6e3ebf3c85