### PR TITLE
fix gallery image loading with updated Vite glob

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -125,7 +125,10 @@ const Index = () => {
 
   // Cargar todas las imágenes ubicadas en assets/gallery para la galería
   const galleryImages = useMemo(() => {
-    const modules = import.meta.glob('/src/assets/gallery/*.{png,jpg,jpeg,webp}', { eager: true, as: 'url' });
+    const modules = import.meta.glob('@/assets/gallery/*.{png,jpg,jpeg,webp}', {
+      eager: true,
+      import: 'url',
+    }) as Record<string, string>;
     return Object.entries(modules)
       .sort((a, b) => a[0].localeCompare(b[0]))
       .map(([, url]) => url);


### PR DESCRIPTION
## Summary
- use Vite `import: 'url'` glob option and path alias to load gallery images

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint`
- `npm run build` *(fails: Loading PostCSS Plugin failed: Cannot find module '@tailwindcss/postcss')*

------
https://chatgpt.com/codex/tasks/task_b_68b6db98dc78832eb4b3b19fbc7820ff