### PR TITLE
fix: treat API as commonjs to avoid ESM exports error

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -1,3 +1,3 @@
 {
-  "type": "module"
+  "type": "commonjs"
 }


### PR DESCRIPTION
## Summary
- fix serverless function export issue by setting api package type to commonjs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b82b433c7c832e9e405db0f38b56a0