### PR TITLE
fix: ensure API builds as ESM module

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "paths": {
       "@/*": ["./src/*"]
     },
+    "module": "ESNext",
     "noImplicitAny": false,
     "noUnusedParameters": false,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
- configure TypeScript compiler to emit ES modules so serverless API avoids `exports is not defined`

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_b_68b83deb71e4832e8c86786a9c50247a